### PR TITLE
Escape some parens

### DIFF
--- a/tablist-filter.el
+++ b/tablist-filter.el
@@ -72,7 +72,7 @@
      ((not filter) `(not ,$2))
      ((filter and filter) `(and ,$1 ,$3))
      ((filter or filter) `(or ,$1 ,$3))
-     ((?( filter ?)) $2))))
+     ((?\( filter ?\)) $2))))
 
 (defun tablist-filter-parser-init (&optional reinitialize interactive)
   (interactive (list t t))


### PR DESCRIPTION
Solves this byte-compile warning

tablist-filter.el:50:1:Warning: unescaped character literals `?(', `?)'
detected!

Which was introduced by this Emacs commit:
https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=c2bbdc3316487e34eba1470dd059c0c290431e00