### PR TITLE
Teach outline-minor-mode about our very own heading syntax

### DIFF
--- a/tablist-filter.el
+++ b/tablist-filter.el
@@ -32,6 +32,10 @@
 (defvar wisent-eoi-term)
 (declare-function wisent-parse "semantic/wisent/wisent.el")
 
+;;
+;; *Variables
+;;
+
 (defvar tablist-filter-binary-operator
   '((== . tablist-filter-op-equal)
     (=~ . tablist-filter-op-regexp)
@@ -73,6 +77,10 @@
      ((filter and filter) `(and ,$1 ,$3))
      ((filter or filter) `(or ,$1 ,$3))
      ((?\( filter ?\)) $2))))
+
+;;
+;; *Filter Parsing
+;;
 
 (defun tablist-filter-parser-init (&optional reinitialize interactive)
   (interactive (list t t))
@@ -255,6 +263,10 @@
          (_ (error "Invalid filter: %s" filter)))))
     (feval filter)))
 
+;;
+;; *Filter Operators
+;;
+
 (defun tablist-filter-get-item-by-name (entry col-name)
   (let* ((col (cl-position col-name tabulated-list-format
                            :key 'car
@@ -343,7 +355,7 @@ and \(...\) to group expressions.")
        (help-mode)))))
 
 ;;
-;; **Filter Functions
+;; *Filter Functions
 ;;
 
 ;; filter ::= nil | named | fn | (OP OP1 [OP2])
@@ -392,7 +404,7 @@ else return nil."
     (_ (funcall fn filter))))
 
 ;;
-;; Reading filter
+;; *Reading Filter
 ;;
 
 (defvar tablist-filter-edit-history nil)

--- a/tablist-filter.el
+++ b/tablist-filter.el
@@ -445,4 +445,7 @@ else return nil."
       filter)))
 
 (provide 'tablist-filter)
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
 ;;; tablist-filter.el ends here

--- a/tablist-filter.el
+++ b/tablist-filter.el
@@ -446,6 +446,7 @@ else return nil."
 
 (provide 'tablist-filter)
 ;; Local Variables:
+;; outline-regexp: ";;\\(\\(?:[;*]+ \\| \\*+\\)[^\s\t\n]\\|###autoload\\)\\|("
 ;; indent-tabs-mode: nil
 ;; End:
 ;;; tablist-filter.el ends here

--- a/tablist.el
+++ b/tablist.el
@@ -1939,6 +1939,7 @@ the 0-th column as numbers by the less-than relation."
 
 (provide 'tablist)
 ;; Local Variables:
+;; outline-regexp: ";;\\(\\(?:[;*]+ \\| \\*+\\)[^\s\t\n]\\|###autoload\\)\\|("
 ;; indent-tabs-mode: nil
 ;; End:
 ;;; tablist.el ends here

--- a/tablist.el
+++ b/tablist.el
@@ -1938,4 +1938,7 @@ the 0-th column as numbers by the less-than relation."
                       (aref (cadr e2) column)))))
 
 (provide 'tablist)
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
 ;;; tablist.el ends here


### PR DESCRIPTION
Such `;; *headings` are unusual, but `outline-minor-mode` can be taught how to deal with them anyway.

Also ensure spaces are used for indentation.  We cannot just assume that each and every contributor has globally set `indent-tabs-mode` to the value that we like.