### PR TITLE
monkey-patch `wisent-total-conflicts` for Emacs 27.0.90

### DIFF
--- a/tablist-filter.el
+++ b/tablist-filter.el
@@ -74,6 +74,20 @@
      ((filter or filter) `(or ,$1 ,$3))
      ((?\( filter ?\)) $2))))
 
+(defun tablist--patch-wisent-total-conflicts (fn &rest args)
+  "Monkey patch `wisent-total-conflicts' to work around errors in 27.0.90.
+Supply a fictitious `load-file-name' to satisfy the code, and
+then call FN with ARGS.  This patch can be removed when the bug
+is resolved: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=39911"
+  (if (wisent-source)
+      (apply fn args)
+    (let ((load-file-name "tablist-fictitious-file.el"))
+      (apply fn args))))
+
+(unless (version< "27" emacs-version)
+  (advice-add 'wisent-total-conflicts
+              :around #'tablist--patch-wisent-total-conflicts))
+
 (defun tablist-filter-parser-init (&optional reinitialize interactive)
   (interactive (list t t))
   (unless (and tablist-filter-lexer-regexps


### PR DESCRIPTION
This relates to #17, and is only a temporary measure until the upstream bug is fixed.

However, before merging there ought to be more testing, so I'm going to put this in my `init.el` for a while.
