### PR TITLE
Fix build

### DIFF
--- a/tablist-filter.el
+++ b/tablist-filter.el
@@ -27,6 +27,9 @@
 (require 'semantic/wisent/comp)
 (require 'semantic/wisent/wisent))
 
+(eval-when-compile (require 'cl-lib))
+(declare-function cl-position "cl-seq")
+
 ;;; Code:
 
 (defvar wisent-eoi-term)


### PR DESCRIPTION
Require cl-lib at compile time.  cl- macros aren't found otherwise, at least on Emacs 27 and further.  And declare a function.